### PR TITLE
fix: remove hyperlink from main menu to avoid crash

### DIFF
--- a/versions/fabric/1.21.7/config/isxander-main-menu-credits.json
+++ b/versions/fabric/1.21.7/config/isxander-main-menu-credits.json
@@ -3,11 +3,7 @@
 		"bottom_left": [
 			{
 				"text": "Additive 1.37.0 (Beta)",
-				"color": "gold",
-				"click_event": {
-					"action": "open_url",
-					"url": "https://modrinth.com/modpack/additive"
-				}
+				"color": "gold"
 			}
 		]
 	}

--- a/versions/fabric/1.21.8/config/isxander-main-menu-credits.json
+++ b/versions/fabric/1.21.8/config/isxander-main-menu-credits.json
@@ -3,11 +3,7 @@
 		"bottom_left": [
 			{
 				"text": "Additive 1.37.0 (Beta)",
-				"color": "gold",
-				"click_event": {
-					"action": "open_url",
-					"url": "https://modrinth.com/modpack/additive"
-				}
+				"color": "gold"
 			}
 		]
 	}


### PR DESCRIPTION
Due to https://github.com/isXander/main-menu-credits/issues/27